### PR TITLE
Fixed error produced by Overleaf

### DIFF
--- a/aauPhdCollectionThesis/master.tex
+++ b/aauPhdCollectionThesis/master.tex
@@ -1,5 +1,5 @@
 \input{setup/preamble.tex}% package inclusion and set up of the document
-\input{setup/hyphenations.tex}% 
+\input{setup/hyphenations.tex}%
 \input{setup/macros.tex}% my new macros
 
 \begin{document}
@@ -38,10 +38,8 @@ display%
 }{%style
   1cm
 }{%code before title
-  \thispagestyle{empty}\begin{center}\Large
-}[%code after title
-  \end{center}
-]
+  \thispagestyle{empty}\begin{center}\Large\end{center}
+}%code after title
 \includepaper{papers/paperA/paperA}
 \includepaper{papers/paperB/paperB}
 \end{document}


### PR DESCRIPTION
Overleaf doesn't seem to like putting the end statement in the square bracket. I changed this and put it within the curly bracket, which seems to give the same output while removing the error. I can see that my VS Code also auto-removed trailing whitespace.