### PR TITLE
Replaced `mathpazo` with `newpxtext` and `newpxmath`

### DIFF
--- a/aauPhdCollectionThesis/setup/preamble.tex
+++ b/aauPhdCollectionThesis/setup/preamble.tex
@@ -35,7 +35,7 @@
 % rules of the language used in the document.
 \usepackage[danish,english]{babel}
 % Use the palatino font
-\usepackage[sc]{mathpazo}
+\usepackage{newpxtext,newpxmath}
 \linespread{1.05}         % Palatino needs more leading (space between lines)
 % Choose the font encoding
 % Choose the font encoding
@@ -72,12 +72,10 @@
 % Defines new environments such as equation,
 % align and split 
 \usepackage{amsmath}
-% Adds new math symbols
-\usepackage{amssymb}
 % Use theorems in your document
 % The ntheorem package is also used for the example environment
 % When using thmmarks, amsmath must be an option as well. Otherwise \eqref doesn't work anymore.
-\usepackage[framed,amsmath,amsthm,thmmarks]{ntheorem}
+\usepackage[framed,amsmath,thmmarks]{ntheorem}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Page Layout and appearance


### PR DESCRIPTION
Replaced the `mathpazo` font Palatino font package to `newpxtext` and `newpxmath` as this package supports upright greek letters, e.g. $upmu$ like the `upgreek` package. Furthermore, these two packages creates greek letters that are much more in-line with the font package other software programs use, e.g. Adobe Illustrator.